### PR TITLE
Add promsafestr function to model to remove extra characters that cause …

### DIFF
--- a/netbox_sd/model.py
+++ b/netbox_sd/model.py
@@ -23,9 +23,18 @@ class Host:
         self.labels["__meta_netbox_type"] = host_type.value
         self.labels["__meta_netbox_id"] = str(id)
 
+    @staticmethod
+    def promsafestr(labelval: str):
+        # add any special chars here that may appear in custom label names
+        specialChars = " -/\\!"
+        for specialChar in specialChars:
+            labelval = labelval.replace(specialChar, '_')
+        return labelval
+
     def add_label(self, key, value):
         """ Add a netbox prefixed meta label to the host """
-        key = key.replace("-", "_").replace(" ", "_")
+        key = self.promsafestr(key)
+        # key = key.replace("-", "_").replace(" ", "_").replace("/", "")
         logging.debug(f"Add label '{key}' with value '{value}'")
         self.labels[f"%s_%s" % ("__meta_netbox", key)] = str(value)
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4,6 +4,7 @@ from netbox_sd.model import Host, HostList, HostType
 def test_host_labels():
     h = Host(1, "foo.bar.example.com", "10.10.10.10", HostType.VIRTUAL_MACHINE)
     h.add_label("custom_field_foo", "bar")
+    h.add_label("custom_field_foo/bar", "foobar")
     # h.add_label("tag_key", "value")
     # h.add_label("tag_complex", "tag:value")
     # h.add_label("tag_replaced-char", "dash")
@@ -14,6 +15,7 @@ def test_host_labels():
         "__meta_netbox_type": "vm",
         "__meta_netbox_id": "1",
         "__meta_netbox_custom_field_foo": "bar",
+        "__meta_netbox_custom_field_foo_bar": "foobar",
         # "__meta_netbox_tag_complex": "tag:value",
         # "__meta_netbox_tag_replaced_char": "dash",
     }


### PR DESCRIPTION
discovered that our netbox has been setup with some custom labels with a / in the name. This causes prometheus to not load a config file due to invalid label name. 

Have added a small loop to add any extra characters and turn them into _, have also included - and " " from the original code and removed that now redundant line.

chars included  " -/\\!" 

Added check for / to test model.  